### PR TITLE
#38 Формирование списка истории на основе данных (пока можно на заглушке сделать)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2752,6 +2752,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.8.29",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.29.tgz",
+      "integrity": "sha512-Vm6teig8ZWK7rH/lxzVGxZJCljPdmUr6q/3f4fr5F0VWNGVkZEjZOQJsAN8hUHUqn+NK4XHNEpJZS1MwLyDcLw=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "connected-react-router": "^6.8.0",
+    "dayjs": "^1.8.29",
     "history": "^5.0.0",
     "moment": "^2.27.0",
     "primeflex": "^1.3.1",

--- a/client/src/actions/operations.js
+++ b/client/src/actions/operations.js
@@ -1,0 +1,7 @@
+import {createActions} from 'redux-actions';
+
+export const {
+  loadOperations,
+} = createActions({
+  LOAD_OPERATIONS: options => options,
+}, { prefix: 'operations' });

--- a/client/src/actions/operations.js
+++ b/client/src/actions/operations.js
@@ -2,6 +2,12 @@ import {createActions} from 'redux-actions';
 
 export const {
   loadOperations,
+  requestOperations,
+  successOperations,
+  failureOperations,
 } = createActions({
   LOAD_OPERATIONS: options => options,
+  REQUEST_OPERATIONS: () => ({}),
+  SUCCESS_OPERATIONS: items => ({items}),
+  FAILURE_OPERATIONS: error => error,
 }, { prefix: 'operations' });

--- a/client/src/components/OperationsPage/OperationPageDateBlock/OperationPageDateBlock.jsx
+++ b/client/src/components/OperationsPage/OperationPageDateBlock/OperationPageDateBlock.jsx
@@ -7,25 +7,17 @@ import Cart from '../../SettingsPage/Cards/Card.jsx';
 const cx = classnames.bind(styles);
 
 export default class OperationPageDateBlock extends React.Component {
-  state = {
-    date: ''
-  }
-
-  componentDidMount() {
-    let { date } = this.props;
-    this.setState({
-      date
-    })
-  }
-
   render() {
+    const { date, items, togglePopup } = this.props;
     return (
       <div className={cx("container")}>
         <div className={cx("header")}>
-          <h2>{ this.state.date }</h2>
+          <h2>{ date }</h2>
         </div>
-            <Cart handlePopUp={ this.props.togglePopup } />
-            <Cart handlePopUp={ this.props.togglePopup } />
+
+        {items && items.map((item, key) => (
+          <Cart key={key} {...item} handlePopUp={ togglePopup } />
+        ))}
       </div>
     )
   }

--- a/client/src/components/OperationsPage/OperationsPage.jsx
+++ b/client/src/components/OperationsPage/OperationsPage.jsx
@@ -16,7 +16,8 @@ export default class OperationsPage extends Component {
         incomeAmount: 21200,
         expensesAmount: 17300,
         date: new Date(),
-        openPopup: false
+        openPopup: false,
+        groups: [],
     }
 
     togglePopup = () => {
@@ -29,6 +30,12 @@ export default class OperationsPage extends Component {
     }
 
     render() {
+        const groupsMap = this.props.groups;
+        const groupsArray = [];
+        // неожидал что Map нельзя нормально проитерировать в реакте
+        // пришлось преобразовать в массив, @todo: избавиться от Map в компоненте
+        groupsMap.forEach((items, date) => groupsArray.push({ date, items }));
+
         let popup = this.state.openPopup ? (<EditOperationPage togglePopup={ this.togglePopup } />) : null;
         let calendarSettings = {
             firstDayOfWeek: 1,
@@ -69,9 +76,9 @@ export default class OperationsPage extends Component {
                     </div>
                 </div>
                 <div className={cx("body")}>
-                    <OperationsPageDateBlock date = '01-07-2020' togglePopup={ this.togglePopup } />
-                    <OperationsPageDateBlock date = '30-06-2020' togglePopup={ this.togglePopup } />
-                    <OperationsPageDateBlock date = '29-06-2020' togglePopup={ this.togglePopup } />
+                    {groupsArray.map(({date, items}, key)=> (
+                      <OperationsPageDateBlock key={key} date={date} items={items} togglePopup={ this.togglePopup } />
+                    ))}
                 </div>
                 <div className={cx("upBtnWrapper")} style={{display: 'none'}}>
                     <Button icon="pi pi-arrow-up" className="p-button-secondary" />

--- a/client/src/components/SettingsPage/Cards/Card.jsx
+++ b/client/src/components/SettingsPage/Cards/Card.jsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import classnames from 'classnames/bind';
-import PropTypes from 'prop-types';
-
 import { Card } from 'primereact/card';
-
 import styles from './Card.scss';
 
 const cx = classnames.bind(styles); 
 
-export default (props) => {
-
-    let { type, regularity } = props;
-
-    type = 'Доход';
-    regularity = 'Ежемесячно';
-
-    let typeOf = type === 'Доход' ? `${cx("greenCard")}` : `${cx("redCard")}`;
+export default ({ type, repetitive, value, title, handlePopUp }) => {
+    const typeText = type === 'income' ? 'Доход' : 'Расход';
+    let typeOf = type === 'income' ? `${cx("greenCard")}` : `${cx("redCard")}`;
 
     return(
-        <div className={cx("card")} onClick={() => props.handlePopUp()}>
-            <Card title={type} subTitle={`10 марта ` + `(` + regularity + `)` } className={typeOf}>
-                22000 p.
+        <div className={cx("card")} onClick={handlePopUp}>
+            <Card
+              title={title}
+              subTitle={`${typeText} ${repetitive ? '(Ежемесячно)' : ''}` }
+              className={typeOf}
+            >
+                {value} p.
                 <i className="pi pi-ellipsis-v" />
             </Card> 
         </div> 

--- a/client/src/components/SettingsPage/Cards/Card.scss
+++ b/client/src/components/SettingsPage/Cards/Card.scss
@@ -13,8 +13,8 @@
         .p-card-content {
             float: right;
             position: relative;
-            right: -10;
-            bottom: 40;
+            right: -10px;
+            bottom: 40px;
             font-size: 20px;
             
             i {
@@ -29,6 +29,6 @@
     }
 
     .redCard {
-        border-left: 4px solid #007AD9;
+        border-left: 4px solid #d90026;
     }
 }

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -9,9 +9,9 @@ import styles from './app.scss';
 import MainPage from "./MainPage/MainPage";
 import RegAuthPage from "../connectors/RegAuthPage";
 import ProfilePage from "../connectors/ProfilePage";
-import OperationsPage from "./OperationsPage/OperationsPage";
 import SettingsPage from "./SettingsPage/SettingsPage";
 import PageIncExp from "./PageIncExp/PageIncExp";
+import OperationsPage from "../connectors/OperationsPage";
 
 const cx = classnames.bind(styles);
 

--- a/client/src/connectors/OperationsPage.js
+++ b/client/src/connectors/OperationsPage.js
@@ -1,0 +1,12 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import OperationsPage from "../components/OperationsPage/OperationsPage";
+import { getGroupsByDate } from "../selectors/operations";
+
+const mapStateToProps = (store) => ({
+  groups: getGroupsByDate(store),
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(OperationsPage);

--- a/client/src/middlewares/app.js
+++ b/client/src/middlewares/app.js
@@ -2,6 +2,7 @@ import {
   init,
 } from '../actions/app';
 import { logout, reset as resetUser } from "../actions/user";
+import { loadOperations } from "../actions/operations";
 
 
 export default store => next => async action => {
@@ -10,7 +11,7 @@ export default store => next => async action => {
 
   switch(action.type) {
     case init.toString():
-      console.log('init app middleware');
+      store.dispatch(loadOperations({ pageSize: 0 }));
       break;
     case logout.toString():
       store.dispatch(resetUser());

--- a/client/src/middlewares/operations.js
+++ b/client/src/middlewares/operations.js
@@ -1,0 +1,35 @@
+import { failureOperations, loadOperations, requestOperations, successOperations } from "../actions/operations";
+import { getAxios } from "../services/axios-singleton";
+import { getToken } from "../selectors/user";
+
+
+export default store => next => async action => {
+  next(action);
+  const state = store.getState();
+
+  switch(action.type) {
+    case loadOperations.toString():
+      store.dispatch(requestOperations());
+      store.dispatch(await fetchOperations(state, action));
+      break;
+    default:
+      break;
+  }
+}
+
+export const fetchOperations = async (state, action) => {
+  const token = getToken(state);
+  const axios = getAxios(token);
+  const params = action.payload;
+  try {
+    const response = await axios.get('/operations', { params });
+    return {
+      type: successOperations.toString(),
+      payload: response.data
+    };
+  } catch (error) {
+    const { data } = error.response || {};
+    console.error(data && data.message);
+    return failureOperations((data && data.message) || 'Connect error. Try later');
+  }
+};

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,5 +1,6 @@
 import appReducer from './app';
 import userReducer from './user';
+import operationsReducer from './operations';
 import { combineReducers } from 'redux';
 import {connectRouter} from "connected-react-router";
 import {createBrowserHistory} from "history";
@@ -17,6 +18,7 @@ const userPersistConfig = {
 const reducer = combineReducers({
   app: appReducer,
   user: persistReducer(userPersistConfig, userReducer),
+  operations: operationsReducer,
   router: connectRouter(history),
 });
 

--- a/client/src/reducers/operations.js
+++ b/client/src/reducers/operations.js
@@ -1,0 +1,25 @@
+import {handleActions} from 'redux-actions';
+
+import { failureOperations, successOperations } from "../actions/operations";
+
+
+const initialState = {
+  items: [],
+  loadOperationsError: '',
+};
+
+export default handleActions({
+  [successOperations]: (store, { payload: items }) => {
+    return {
+      ...store,
+      items,
+      loadOperationsError: null,
+    }
+  },
+  [failureOperations]: (store, { payload }) => {
+    return {
+      ...store,
+      loadOperationsError: payload,
+    }
+  },
+}, initialState);

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -4,6 +4,7 @@ import { persistStore } from 'redux-persist';
 import { routerMiddleware } from 'connected-react-router';
 import appMiddleware from "../middlewares/app";
 import userMiddleware from "../middlewares/user";
+import operationsMiddleware from "../middlewares/operations";
 
 const composeEnhancers = (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
@@ -15,6 +16,7 @@ export const initStore = (preloadedState = undefined) => {
       routerMiddleware(history),
       appMiddleware,
       userMiddleware,
+      operationsMiddleware,
     ))
   );
 

--- a/client/src/selectors/operations.js
+++ b/client/src/selectors/operations.js
@@ -1,0 +1,35 @@
+import { createSelector } from 'reselect'
+import propOr from 'lodash/fp/propOr';
+import dayjs from 'dayjs';
+import dayjsRU from 'dayjs/locale/ru';
+
+dayjs.locale(dayjsRU);
+
+const selectOperations = state => state.operations || {};
+
+export const getOperationList = createSelector(
+  selectOperations,
+  propOr([], 'items')
+);
+
+export const getOperationByDate = createSelector(
+  getOperationList,
+  items => items.sort((a, b) =>  new Date(b.date) < new Date(a.date) ? -1 : 1)
+);
+
+export const getGroupsByDate = createSelector(
+  getOperationByDate,
+  items => {
+    const groups =  new Map();
+
+    items.forEach(item => {
+      const itemDate = dayjs(item.date);
+      const year = dayjs(itemDate).year() === dayjs().year() ? '' : ' YYYY';
+      const formatDate = itemDate.format(`DD MMMM ${year}, dd`);
+
+      const groupItems = groups.get(formatDate) || [];
+      groups.set(formatDate, [ ...groupItems, item])
+    });
+    return groups;
+  }
+);


### PR DESCRIPTION
Реализовал вывод истории операций. Сделал поэтапно, чтобы можно было проследить шаги реализации: 

* создать экшен loadOperations для инициализации запроса данных в базе
https://github.com/Yudaev/cyan-finance/commit/7247459e8df8df93215a63972c661d00e05f5f9b

* создать мидлвару запроса данных в базе и соответствующие экшены: requestOperations, successOperations, failureOperations
https://github.com/Yudaev/cyan-finance/commit/740773637eb50ba35e177d7955ddcf69c9fbc692

* добавить редьюсер для сохранения данных в стор приложения
https://github.com/Yudaev/cyan-finance/commit/7bdc756b3d23c812290dc35cdc4463e9c80a7fb5

* добавить данные в коннектор компонента, используя селекторы
https://github.com/Yudaev/cyan-finance/commit/7c9a5aa1742aef9def642b30730de2447ef74835

* вывести данные в компонент
https://github.com/Yudaev/cyan-finance/commit/90afd742f8c74273a031fbde442259ee9c104874