### PR TITLE
#62 Доработка компонента статистики: селектор, коннектор и фильтрация данных

### DIFF
--- a/client/src/actions/app.js
+++ b/client/src/actions/app.js
@@ -3,6 +3,6 @@ import {createActions} from 'redux-actions';
 export const {
   init,
 } = createActions({
-  INIT: data => data,
+  INIT: data => data
 }, { prefix: 'app' });
 

--- a/client/src/actions/categories.js
+++ b/client/src/actions/categories.js
@@ -9,6 +9,7 @@ export const {
   requestItem,
   successItem,
   failureItem,
+  clearCategoriesData,
 } = createActions({
   LOAD_LIST: () => ({}),
   REQUEST_LIST: () => ({}),
@@ -18,4 +19,5 @@ export const {
   REQUEST_ITEM: () => ({}),
   SUCCESS_ITEM: item => item,
   FAILURE_ITEM: error => error,
+  CLEAR_CATEGORIES_DATA: () => ({}),
 }, { prefix: 'categories' });

--- a/client/src/actions/operations.js
+++ b/client/src/actions/operations.js
@@ -10,6 +10,7 @@ export const {
   successItem,
   failureItem,
   saveHistoryDate,
+  clearOperationsData,
 } = createActions({
   LOAD_OPERATIONS: options => options,
   REQUEST_OPERATIONS: () => ({}),
@@ -20,4 +21,5 @@ export const {
   SUCCESS_ITEM: item => item,
   FAILURE_ITEM: error => error,
   SAVE_HISTORY_DATE: date => ({ date }),
+  CLEAR_OPERATIONS_DATA: () => ({}),
 }, { prefix: 'operations' });

--- a/client/src/actions/operations.js
+++ b/client/src/actions/operations.js
@@ -10,6 +10,7 @@ export const {
   successItem,
   failureItem,
   saveHistoryDate,
+  saveHistoryType,
   clearOperationsData,
 } = createActions({
   LOAD_OPERATIONS: options => options,
@@ -21,5 +22,6 @@ export const {
   SUCCESS_ITEM: item => item,
   FAILURE_ITEM: error => error,
   SAVE_HISTORY_DATE: date => ({ date }),
+  SAVE_HISTORY_TYPE: type => ({ type }),
   CLEAR_OPERATIONS_DATA: () => ({}),
 }, { prefix: 'operations' });

--- a/client/src/actions/operations.js
+++ b/client/src/actions/operations.js
@@ -9,6 +9,7 @@ export const {
   requestItem,
   successItem,
   failureItem,
+  saveHistoryDate,
 } = createActions({
   LOAD_OPERATIONS: options => options,
   REQUEST_OPERATIONS: () => ({}),
@@ -18,4 +19,5 @@ export const {
   REQUEST_ITEM: () => ({}),
   SUCCESS_ITEM: item => item,
   FAILURE_ITEM: error => error,
+  SAVE_HISTORY_DATE: date => ({ date }),
 }, { prefix: 'operations' });

--- a/client/src/components/OperationsPage/OperationsPage.jsx
+++ b/client/src/components/OperationsPage/OperationsPage.jsx
@@ -27,16 +27,10 @@ export default class OperationsPage extends Component {
         });
     }
 
-    onChangeDate = (date) => {
-        this.setState({ date: date })
-    }
-
     render() {
         const {groups: groupsMap, categories } = this.props;
         const { onChangeDate } = this.props;
         const groupsArray = [];
-        // неожидал что Map нельзя нормально проитерировать в реакте
-        // пришлось преобразовать в массив, @todo: избавиться от Map в компоненте
         groupsMap.forEach((items, date) => groupsArray.push({ date, items }));
 
         let popup = this.state.openPopup ? (<EditOperationPage togglePopup={ this.togglePopup } />) : null;

--- a/client/src/components/OperationsPage/OperationsPage.jsx
+++ b/client/src/components/OperationsPage/OperationsPage.jsx
@@ -27,8 +27,13 @@ export default class OperationsPage extends Component {
         });
     }
 
+    onChangeDate = (date) => {
+        this.setState({ date: date })
+    }
+
     render() {
         const {groups: groupsMap, categories } = this.props;
+        const { onChangeDate } = this.props;
         const groupsArray = [];
         // неожидал что Map нельзя нормально проитерировать в реакте
         // пришлось преобразовать в массив, @todo: избавиться от Map в компоненте
@@ -52,7 +57,7 @@ export default class OperationsPage extends Component {
                 </div>
                 <div className={cx("header")}>
                     <div className={cx("incomeWrapper")}>
-                        <span className={cx("incomeAmount")}>{`${this.props.types.income} р.`}</span>
+                        <span className={cx("incomeAmount")}>{`${this.props.stats.income} р.`}</span>
                         <span className={cx("mark")}>доход</span>
                     </div>
                     <div className="monthWrapper">
@@ -61,7 +66,7 @@ export default class OperationsPage extends Component {
                         className={cx("monthPicker")}
                         inputStyle={{minWidth: "100px"}} 
                         value={this.state.date} 
-                        onChange={(e) => this.setState({ date: e.value })} 
+                        onSelect={(e) => onChangeDate(e.value)}
                         view="month"
                         dateFormat="MM yy"
                         yearNavigator={true}
@@ -69,7 +74,7 @@ export default class OperationsPage extends Component {
                     />
                     </div>
                     <div className={cx("expensesWrapper")}>
-                        <span className={cx("expensesAmount")}>{`${this.props.types.expense} р.`}</span>
+                        <span className={cx("expensesAmount")}>{`${this.props.stats.expense} р.`}</span>
                         <span className={cx("mark")}>расход</span>
                     </div>
                 </div>

--- a/client/src/components/OperationsPage/OperationsPage.jsx
+++ b/client/src/components/OperationsPage/OperationsPage.jsx
@@ -13,8 +13,6 @@ const cx = classnames.bind(styles);
 
 export default class OperationsPage extends Component {
     state = {
-        incomeAmount: 21200,
-        expensesAmount: 17300,
         date: new Date(),
         openPopup: false,
         groups: [],
@@ -54,7 +52,7 @@ export default class OperationsPage extends Component {
                 </div>
                 <div className={cx("header")}>
                     <div className={cx("incomeWrapper")}>
-                        <span className={cx("incomeAmount")}>{`${this.state.incomeAmount} р.`}</span>
+                        <span className={cx("incomeAmount")}>{`${this.props.types.income} р.`}</span>
                         <span className={cx("mark")}>доход</span>
                     </div>
                     <div className="monthWrapper">
@@ -71,7 +69,7 @@ export default class OperationsPage extends Component {
                     />
                     </div>
                     <div className={cx("expensesWrapper")}>
-                        <span className={cx("expensesAmount")}>{`${this.state.expensesAmount} р.`}</span>
+                        <span className={cx("expensesAmount")}>{`${this.props.types.expense} р.`}</span>
                         <span className={cx("mark")}>расход</span>
                     </div>
                 </div>

--- a/client/src/components/StatisticsPage/StatisticsPage.jsx
+++ b/client/src/components/StatisticsPage/StatisticsPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import classnames from 'classnames/bind'
 
 import styles from './StatisticsPage.scss'
@@ -8,16 +8,15 @@ import { Calendar } from 'primereact/calendar'
 import { Chart } from 'primereact/chart'
 import { Button } from 'primereact/button'
 import { Dropdown } from 'primereact/dropdown'
+import dayjs from 'dayjs';
 
 
 const cx = classnames.bind(styles)
 
-class StatisticsPage extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = { 
-            intervalValue: 'день',
-            calendarValue: new Date(),
+export default class StatisticsPage extends Component {
+        state = {
+            calendarValue: null,
+            date: new Date(),
             minDate: null,
             maxDate: null,
             intervalArray: [
@@ -27,11 +26,6 @@ class StatisticsPage extends React.Component {
                 {label: 'Все время', value: 'все время'},
                 {label: 'Интервал', value: 'интервал'},
             ],
-            year: 2020,
-            baseValue: {
-                name: 'Баланс',
-                value: 100000
-            },
             categories: [
                 {
                     name: 'Расход',
@@ -192,7 +186,6 @@ class StatisticsPage extends React.Component {
                 }
             },
         }
-    }
 
     getLabels = () => {
         let labelsArr = Object.keys(this.state.categories[0]?.list).map(
@@ -236,82 +229,94 @@ class StatisticsPage extends React.Component {
             clear: 'Limpiar',
         };
 
-        if (this.state.intervalValue === 'день') {
+        const { onChangeDate, type } = this.props;
+        const { yearNow } = this.props;
+
+        if (type === 'день') {
             return <Calendar
                         inputStyle={{
+                            padding: '.25em 0em 0em 0em',
                             border: 'none',
                             backgroundColor: '#ffffff'
                         }}
-                        placeholder={`${this.state.calendarValue}`}
+                        placeholder={`${this.state.date}`}
                         monthNavigator
                         yearNavigator
                         locale={calendarSettings}
                         yearRange='2010:2030'
                         dateFormat='dd MM yy'
-                        value={this.state.calendarValue}
-                        onSelect={e => this.setState({calendarValue: e.value})}
+                        readOnlyInput
+                        value={this.state.date}
+                        onSelect={e => onChangeDate(e.value)}
                     />
         }
 
-        if (this.state.intervalValue === 'месяц') {
+        if (type === 'месяц') {
             return <Calendar
                         inputStyle={{
                             border: 'none',
-                            backgroundColor: '#ffffff'
+                            backgroundColor: '#ffffff',
+                            padding: '.25em 0em 0em 0em',
                         }}
-                        placeholder={`${this.state.calendarValue}`}
+                        placeholder={`${this.state.date}`}
                         view='month'
                         monthNavigator                        
                         yearNavigator
                         locale={calendarSettings}
                         yearRange='2010:2030'
-                        value={this.state.calendarValue}
+                        readOnlyInput
+                        value={this.state.date}
                         dateFormat='MM yy'
-                        onSelect={(e) => this.setState({calendarValue: e.value})} 
+                        onSelect={e => onChangeDate(e.value)} 
                     />
         }
 
-        if (this.state.intervalValue === 'год') {
+        if (type === 'год') {
             
-            let years = [
-                {label: 2020, value: 2020},
-                {label: 2021, value: 2021}
-            ]
+            const { years } = this.props;
+            const formatYear = dayjs(this.state.year).year();
 
             return <Dropdown
-                        placeholder={`${this.state.year}`}
-                        value={this.state.year}
+                        placeholder={`${formatYear}`}
+                        value={yearNow}
                         options={years}
                         className={cx('year')}
-                        onChange={e => this.setState({ year: e.value })}
+                        onChange={e => onChangeDate(e.value)}
                     />
         }
 
-        if (this.state.intervalValue === 'все время') {
+        if (type === 'все время') {
             return null
         }
     
-        if (this.state.intervalValue === 'интервал') {
+        if (type === 'интервал') {
             return <Calendar
                         inputStyle={{
                             border: 'none',
                             backgroundColor: '#ffffff',
-                            width: '150%'
+                            width: '110%',
+                            padding: '0.25em 0em 0em 0.1em',
                         }}
+                        className={cx('interval')}
                         selectionMode='range'
                         placeholder='Выберите интервал...'
                         minDate={this.state.minDate}
                         maxDate={this.state.maxDate}
-                        readOnlyInput
                         locale={calendarSettings}
-                        dateFormat='d MM y'
-                        value={this.state.calendarValue}
-                        onChange={(e) => this.setState({calendarValue: e.value})} 
+                        dateFormat='d M y'
+                        readOnlyInput
+                        value={yearNow}
+                        onChange={e => onChangeDate(e.value) }
                     />
         }
     }
 
     render() {
+
+        const { stats, onChangeType, type } = this.props;
+
+        // Вытащить прогрессбары в отдельный компонент
+        // Связать компонент прогрессбаров с Tree
 
         let incomeColorClasses = ['cyan', 'lilac', 'pink', 'brown', 'violet']
         let spendColorClasses = ['pinkRed', 'blue', 'yellow', 'red', 'yellowGreen']
@@ -374,9 +379,9 @@ class StatisticsPage extends React.Component {
                         <div className={cx('controls')}>
                             <Dropdown
                                 className={cx('dropdown')}
-                                value={`Показать за ` + this.state.intervalValue}
-                                onChange={ (e) => { this.setState({ intervalValue: e.value }) }}
-                                placeholder={'Показать за ' + this.state.intervalValue}
+                                value={`Показать за ` + type}
+                                onChange={ e => onChangeType(e.value) }
+                                placeholder={'Показать за ' + type}
                                 options={this.state.intervalArray}
                             />
                             <div className={cx('calendar')}>
@@ -388,16 +393,15 @@ class StatisticsPage extends React.Component {
                         <div className={cx('title')} key={Date.now()} >
                                 <div className={cx('title-bar')}>
                                     <div className={cx('label')}>
-                                        <span>{this.state.baseValue.name}</span>
+                                        <span>Баланс</span>
                                     </div>
                                         <ProgressBar
-                                            value={this.state.rest.value(this.state.categories[1].value(), this.state.categories[0].value())}
-                                            id={`${11}`}
+                                            value={this.state.rest.value(stats.income, stats.expense)}
                                             className={cx('ttl-bar')}
                                             showValue={false}
                                         />
                                     <div className={cx('value')}>
-                                        <span>{this.state.rest.value(this.state.categories[1].value(), this.state.categories[0].value())} p.</span>
+                                        <span>{this.state.rest.value(stats.income, stats.expense)} p.</span>
                                     </div>
                                 </div>
 
@@ -406,13 +410,12 @@ class StatisticsPage extends React.Component {
                                         <span>{this.state.categories[1].name}</span>
                                     </div>
                                         <ProgressBar
-                                            id={`${12}`}
-                                            value={this.state.categories[1].value()}
+                                            value={stats.income}
                                             className={cx('ttl-bar', 'incomes')}
                                             showValue={false}
                                         />
                                     <div className={cx('value')}>
-                                        <span>{this.state.categories[1].value()} p.</span>
+                                        <span>{stats.income} p.</span>
                                     </div>
                                 </div>
 
@@ -421,13 +424,12 @@ class StatisticsPage extends React.Component {
                                         <span>{this.state.categories[0].name}</span>
                                     </div>
                                         <ProgressBar
-                                            value={this.state.categories[0].value()}
-                                            id={`${13}`}
+                                            value={stats.expense}
                                             className={cx('ttl-bar', 'expense')}
                                             showValue={false}
                                         />
                                     <div className={cx('value')}>
-                                        <span>{this.state.categories[0].value()} p.</span>
+                                        <span>{stats.expense} p.</span>
                                     </div>
                                 </div>
                         </div>
@@ -444,6 +446,4 @@ class StatisticsPage extends React.Component {
             )
     }
 }
-
-export default StatisticsPage;
 

--- a/client/src/components/StatisticsPage/StatisticsPage.scss
+++ b/client/src/components/StatisticsPage/StatisticsPage.scss
@@ -16,6 +16,7 @@
                     }
 
                     .calendar {
+                        font-size: 12px;
                         text-align: right;
                         float: right;
                         padding-right: 1.8em;
@@ -25,12 +26,18 @@
                             .p-inputtext {
                                 box-shadow: none;
                             }
+
+                            .p-datepicker {
+                                right: -19px;
+                                left: -190px !important;
+                            }
     
                             .p-datepicker-year {
                                 padding: 0em 0.5em;
                             }
 
                             .year {
+                               font-size: 12px;
                                border: none;
                                box-shadow: none;
                                padding: 0em 4em;
@@ -69,17 +76,18 @@
                 .title-bar {
                     padding: 0.5em;
                     display: flex;
-                    align-items: center;
+                    align-items: baseline;
                     text-align: center;
 
                     .label {
-                        width: 25%
+                        text-align: left;
+                        width: 22%
                     }
 
                     .ttl-bar {
                         text-align: center;
                         float: right;
-                        width: 60%;
+                        width: 56%;
                         height: 9;
                         border-radius: 1em;
                     }
@@ -97,7 +105,8 @@
                     }
 
                     .value {
-                        width: 20%
+                        text-align: right;
+                        width: 22%
                     }
                 }
             }
@@ -110,16 +119,21 @@
         .progress-bar {
             display: flex;
             padding: 0.5em;
-            align-items: center;
+            align-items: baseline;
             text-align: center;
 
             .pb-title {
-                width: 25%;
+                width: 20%;
+                text-align: left;
+            }
+
+            .pb-title > p {
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
 
             .pb-bar {
-                padding-left: 0.5em;
-                width: 60%;
+                width: 58%;
 
                 .bar {
                     height: 9;
@@ -188,7 +202,14 @@
             }
 
             .pb-value {
-                width: 20%;
+                padding-left: 0.35em;
+                text-align: right;
+                width: 22%;
+            }
+
+            .pb-value > p {
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
 
             .spend {
@@ -201,9 +222,7 @@
         }
 
         .footer-button {
-            position: absolute;
-            padding: 2em;
-            bottom: 15;  
+            padding: 2em; 
             text-align: center;
             width: 100%;
         }

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -12,7 +12,7 @@ import ProfilePage from "../connectors/ProfilePage";
 import SettingsPage from "./SettingsPage/SettingsPage";
 import PageIncExp from "../connectors/PageIncExp";
 import OperationsPage from "../connectors/OperationsPage";
-import StatisticsPage from "./StatisticsPage/StatisticsPage";
+import StatisticsPage from "../connectors/StatisticsPage";
 
 const cx = classnames.bind(styles);
 

--- a/client/src/connectors/OperationsPage.js
+++ b/client/src/connectors/OperationsPage.js
@@ -3,10 +3,12 @@ import { connect } from 'react-redux';
 import OperationsPage from "../components/OperationsPage/OperationsPage";
 import { getGroupsByDate } from "../selectors/operations";
 import { getCategoryListAsObject } from "../selectors/categories";
+import { getAllTimeStats } from "../selectors/operations";
 
 const mapStateToProps = (store) => ({
   groups: getGroupsByDate(store),
   categories: getCategoryListAsObject(store),
+  types: getAllTimeStats(store)
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({}, dispatch);

--- a/client/src/connectors/OperationsPage.js
+++ b/client/src/connectors/OperationsPage.js
@@ -3,14 +3,18 @@ import { connect } from 'react-redux';
 import OperationsPage from "../components/OperationsPage/OperationsPage";
 import { getGroupsByDate } from "../selectors/operations";
 import { getCategoryListAsObject } from "../selectors/categories";
-import { getAllTimeStats } from "../selectors/operations";
+import { getValuesByMonth } from "../selectors/operations";
+import { saveHistoryDate } from "../actions/operations";
+
 
 const mapStateToProps = (store) => ({
   groups: getGroupsByDate(store),
   categories: getCategoryListAsObject(store),
-  types: getAllTimeStats(store)
+  stats: getValuesByMonth(store)
 });
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({}, dispatch);
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  onChangeDate: date => saveHistoryDate(date)
+}, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(OperationsPage);

--- a/client/src/connectors/StatisticsPage.js
+++ b/client/src/connectors/StatisticsPage.js
@@ -1,0 +1,22 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import StatisticsPage from "../components/StatisticsPage/StatisticsPage";
+import { saveHistoryDate } from "../actions/operations";
+import { saveHistoryType } from "../actions/operations";
+import { getTypeSwitch, getValuesByType, getGroupByYears, getDate } from "../selectors/statistics";
+import { getCategoryListAsObject } from "../selectors/categories";
+
+
+const mapStateToProps = (store) => ({
+  yearNow: getDate(store),
+  years: getGroupByYears(store),
+  stats: getValuesByType(store),
+  type: getTypeSwitch(store),
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  onChangeDate: date => saveHistoryDate(date),
+  onChangeType: type => saveHistoryType(type)
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(StatisticsPage);

--- a/client/src/middlewares/app.js
+++ b/client/src/middlewares/app.js
@@ -1,9 +1,9 @@
 import {
-  init,
+  init
 } from '../actions/app';
-import { logout, reset as resetUser } from "../actions/user";
-import { loadOperations } from "../actions/operations";
-import { loadList as loadCategories } from "../actions/categories";
+import { logout, reset as resetUser, successAuth, successReg } from "../actions/user";
+import { loadOperations, clearOperationsData } from "../actions/operations";
+import { loadList as loadCategories, clearCategoriesData } from "../actions/categories";
 
 
 export default store => next => async action => {
@@ -17,6 +17,13 @@ export default store => next => async action => {
       break;
     case logout.toString():
       store.dispatch(resetUser());
+      store.dispatch(clearOperationsData());
+      store.dispatch(clearCategoriesData());
+      break;
+    case successReg.toString():
+    case successAuth.toString():
+      store.dispatch(loadOperations({ pageSize: 0 }));
+      store.dispatch(loadCategories());
       break;
     default:
       break;

--- a/client/src/middlewares/user.js
+++ b/client/src/middlewares/user.js
@@ -9,7 +9,7 @@ import {
   successReg,
   failureReg, clearAuthError, clearRegError,
 } from '../actions/user';
-
+import { loadData } from '../actions/app'
 
 export default store => next => async action => {
   next(action);

--- a/client/src/middlewares/user.js
+++ b/client/src/middlewares/user.js
@@ -9,7 +9,6 @@ import {
   successReg,
   failureReg, clearAuthError, clearRegError,
 } from '../actions/user';
-import { loadData } from '../actions/app'
 
 export default store => next => async action => {
   next(action);

--- a/client/src/reducers/categories.js
+++ b/client/src/reducers/categories.js
@@ -1,6 +1,6 @@
 import {handleActions} from 'redux-actions';
 
-import { failureItem, failureList, successItem, successList } from "../actions/categories";
+import { failureItem, failureList, successItem, successList, clearCategoriesData } from "../actions/categories";
 
 const initialState = {
   items: [],
@@ -35,4 +35,10 @@ export default handleActions({
       itemError: payload,
     }
   },
+  [clearCategoriesData]: (store) => {
+    return {
+      ...store,
+      ...initialState
+    }
+  }
 }, initialState);

--- a/client/src/reducers/operations.js
+++ b/client/src/reducers/operations.js
@@ -1,10 +1,11 @@
 import {handleActions} from 'redux-actions';
 
-import { failureItem, failureOperations, successItem, successOperations } from "../actions/operations";
+import { failureItem, failureOperations, successItem, successOperations, saveHistoryDate } from "../actions/operations";
 
 
 const initialState = {
   items: [],
+  date: new Date(),
   loadOperationsError: '',
   itemError: '',
 };
@@ -36,4 +37,10 @@ export default handleActions({
       itemError: payload,
     }
   },
+  [saveHistoryDate]: (store, { payload }) => {
+    return {
+      ...store,
+      date: payload.date
+    }
+  }
 }, initialState);

--- a/client/src/reducers/operations.js
+++ b/client/src/reducers/operations.js
@@ -1,11 +1,12 @@
 import {handleActions} from 'redux-actions';
 
-import { failureItem, failureOperations, successItem, successOperations, saveHistoryDate, clearOperationsData } from "../actions/operations";
+import { failureItem, failureOperations, successItem, successOperations, saveHistoryDate, clearOperationsData, saveHistoryType } from "../actions/operations";
 
 
 const initialState = {
   items: [],
   date: new Date(),
+  type: 'день',
   loadOperationsError: '',
   itemError: '',
 };
@@ -41,6 +42,12 @@ export default handleActions({
     return {
       ...store,
       date: payload.date
+    }
+  },
+  [saveHistoryType]: (store, { payload }) => {
+    return {
+      ...store, 
+      type: payload.type
     }
   },
   [clearOperationsData]: (store) => {

--- a/client/src/reducers/operations.js
+++ b/client/src/reducers/operations.js
@@ -1,6 +1,6 @@
 import {handleActions} from 'redux-actions';
 
-import { failureItem, failureOperations, successItem, successOperations, saveHistoryDate } from "../actions/operations";
+import { failureItem, failureOperations, successItem, successOperations, saveHistoryDate, clearOperationsData } from "../actions/operations";
 
 
 const initialState = {
@@ -41,6 +41,12 @@ export default handleActions({
     return {
       ...store,
       date: payload.date
+    }
+  },
+  [clearOperationsData]: (store) => {
+    return {
+      ...store, 
+      ...initialState
     }
   }
 }, initialState);

--- a/client/src/selectors/operations.js
+++ b/client/src/selectors/operations.js
@@ -43,22 +43,28 @@ export const getDate = createSelector(
 export const getMonth = createSelector(
   getDate,
   date => { 
-    const currentMonth = dayjs(date).month();
-    return currentMonth;
+    const currentDatesObject = {
+      month: dayjs(date).month(),
+      year: dayjs(date).year(),
+    }
+    return currentDatesObject;
   },
 );
 
 export const getValuesByMonth = createSelector(
   [getMonth, getOperationList],
-  (currentMonth, items) => {
+  (currentDatesObject, items) => {
     const stats = {
       income: 0,
       expense: 0,
     };
     items.forEach(item => {
-      const itemMonth = dayjs(item.date).month(); 
-      if (item.type === 'income' && itemMonth == currentMonth) stats.income += Number(item.value);
-      if (item.type === 'expense' && itemMonth == currentMonth) stats.expense += Number(item.value);
+      const itemDatesObject = {
+        month: dayjs(item.date).month(),
+        year: dayjs(item.date).year()
+      }
+      if (item.type === 'income' && JSON.stringify(currentDatesObject) === JSON.stringify(itemDatesObject)) stats.income += Number(item.value);
+      if (item.type === 'expense' && JSON.stringify(currentDatesObject) === JSON.stringify(itemDatesObject)) stats.expense += Number(item.value);
     });
     return stats;
   }

--- a/client/src/selectors/operations.js
+++ b/client/src/selectors/operations.js
@@ -6,6 +6,7 @@ import dayjsRU from 'dayjs/locale/ru';
 dayjs.locale(dayjsRU);
 
 const selectOperations = state => state.operations || {};
+const selectDate = state => state.operations|| {};
 
 export const getOperationList = createSelector(
   selectOperations,
@@ -34,17 +35,31 @@ export const getGroupsByDate = createSelector(
   }
 );
 
-export const getAllTimeStats = createSelector(
-  getOperationList,
-  items => {
-    const types = {
+export const getDate = createSelector(
+  selectDate,
+  propOr({}, 'date'),
+);
+
+export const getMonth = createSelector(
+  getDate,
+  date => { 
+    const currentMonth = dayjs(date).month();
+    return currentMonth;
+  },
+);
+
+export const getValuesByMonth = createSelector(
+  [getMonth, getOperationList],
+  (currentMonth, items) => {
+    const stats = {
       income: 0,
       expense: 0,
     };
     items.forEach(item => {
-      if (item.type === 'income') types.income += Number(item.value);
-      if (item.type === 'expense') types.expense += Number(item.value);
+      const itemMonth = dayjs(item.date).month(); 
+      if (item.type === 'income' && itemMonth == currentMonth) stats.income += Number(item.value);
+      if (item.type === 'expense' && itemMonth == currentMonth) stats.expense += Number(item.value);
     });
-    return types;
+    return stats;
   }
 );

--- a/client/src/selectors/operations.js
+++ b/client/src/selectors/operations.js
@@ -33,3 +33,18 @@ export const getGroupsByDate = createSelector(
     return groups;
   }
 );
+
+export const getAllTimeStats = createSelector(
+  getOperationList,
+  items => {
+    const types = {
+      income: 0,
+      expense: 0,
+    };
+    items.forEach(item => {
+      if (item.type === 'income') types.income += Number(item.value);
+      if (item.type === 'expense') types.expense += Number(item.value);
+    });
+    return types;
+  }
+);

--- a/client/src/selectors/statistics.js
+++ b/client/src/selectors/statistics.js
@@ -1,0 +1,113 @@
+import { createSelector } from 'reselect'
+import propOr from 'lodash/fp/propOr';
+import dayjs from 'dayjs';
+import dayjsRU from 'dayjs/locale/ru';
+
+const _ = require('lodash');
+const isBetween = require('dayjs/plugin/isBetween');
+dayjs.extend(isBetween);
+
+dayjs.locale(dayjsRU);
+
+const selectOperations = state => state.operations || {};
+const selectDate = state => state.operations || {};
+const selectType = state => state.operations || {};
+
+export const getOperations = createSelector(
+  selectOperations,
+  propOr([], 'items')
+);
+
+export const getDate = createSelector(
+  selectDate,
+  propOr({}, 'date')
+);
+
+export const getTypeSwitch = createSelector(
+  selectType,
+  propOr({}, 'type')
+);
+
+export const getGroupByYears = createSelector(
+  getOperations,
+  items => {
+    const years = [];
+    items.forEach(
+      item => {
+        const currentYear = dayjs(item.date).year();
+        years.push(currentYear);
+      });
+    const onlyUniq = _.uniqWith(years, _.isEqual);
+    return onlyUniq;
+  }
+);
+
+export const getCurrentDatesObject = createSelector(
+  getDate,
+  date => {
+    const currentDates = {
+      day: dayjs(date).day(),
+      month: dayjs(date).month(),
+      year: dayjs(date).year()
+    };
+    return currentDates;
+  },
+);
+
+export const getValuesByType = createSelector(
+  [getCurrentDatesObject, getOperations, getTypeSwitch, getDate],
+  (currentDates, items, type, date) => {
+    const stats = {
+      income: 0,
+      expense: 0,
+    };
+    items.forEach(item => {
+      const itemDates = {
+        day: dayjs(item.date).day(),
+        month: dayjs(item.date).month(),
+        year: dayjs(item.date).year()
+      }
+      switch (type) {
+        case 'день': 
+          if (item.type === 'income' && JSON.stringify(currentDates) === JSON.stringify(itemDates)) stats.income += Number(item.value);
+          if (item.type === 'expense' && JSON.stringify(currentDates) === JSON.stringify(itemDates)) stats.expense += Number(item.value);
+          break;
+        case 'месяц':
+          delete currentDates.day;
+          delete itemDates.day;
+            if (item.type === 'income' && JSON.stringify(currentDates) === JSON.stringify(itemDates)) stats.income += Number(item.value);
+            if (item.type === 'expense' && JSON.stringify(currentDates) === JSON.stringify(itemDates)) stats.expense += Number(item.value);
+          break;
+        case 'год':
+            if (item.type === 'income' && date == itemDates.year) stats.income += Number(item.value);
+            else if (dayjs(date).year() == itemDates.year && item.type === 'income') stats.income += Number(item.value);
+
+            if (item.type === 'expense' && date == itemDates.year) stats.expense += Number(item.value);
+            else if (dayjs(date).year() == itemDates.year && item.type === 'expense') stats.expense += Number(item.value);
+          break;
+        case 'все время':
+            if (item.type === 'income') stats.income += Number(item.value);
+            if (item.type === 'expense') stats.expense += Number(item.value);
+          break;
+        case 'интервал':
+          const isDate = _.isDate(date);
+            if (isDate) return true;
+            else {
+              const isBetween = dayjs(item.date).isBetween(date[0], date[1], 'day', '[]');
+              if (item.type === 'income' && isBetween) stats.income += Number(item.value);
+              if (item.type === 'expense' && isBetween ) stats.expense += Number(item.value);
+            }
+          break;
+        default: 
+          return stats;
+      }
+    });
+    return stats;
+  }
+);
+
+
+
+
+
+

--- a/server/config.json.sample
+++ b/server/config.json.sample
@@ -1,0 +1,8 @@
+{
+  "port": 8000,
+  "mongoHost": "localhost",
+  "mongoPort": 27017,
+  "mongoDB": "cyan",
+  "tokenSecret": "SecretPhrase",
+  "saltRounds": 5
+}

--- a/server/config.json.sample
+++ b/server/config.json.sample
@@ -1,8 +1,0 @@
-{
-  "port": 8000,
-  "mongoHost": "localhost",
-  "mongoPort": 27017,
-  "mongoDB": "cyan",
-  "tokenSecret": "SecretPhrase",
-  "saltRounds": 5
-}

--- a/server/config.json.sample
+++ b/server/config.json.sample
@@ -1,8 +1,0 @@
-{
-  "port": 8000,
-  "mongoHost": "localhost",
-  "mongoPort": 27001,
-  "mongoDB": "dbName",
-  "tokenSecret": "SecretPhrase",
-  "saltRounds": 5
-}


### PR DESCRIPTION
_**Сперва нужно смержить #34, иначе будут конфликты**_ 

В этом PR: 

1. Front:

- Селектор для группировки годов;

- Селектор для выборки типа отображения и правильного подсчета транзакций, входящих в период;

- Экшен и редюсер для сохранения типа периода в редакс;

- Коннектор для компонента статистики;

2. Верстка

- Сделал font-size для дат равным  12px. Открывал на своем телефоне, если выбран показать за интервал - тогда даты съезжали ниже или не помещались в блок;

- Стилизовал отображение названий категорий (по левому краю) и сумму категорий (по правому краю);

- Кнопку "Выгрузить статистику" опустил вниз после прогрессбаров;

- Добавил правило, сокращающее название категории, если оно не умещается в блоке;

3. Баги

- Добавил более точное сравнение для выборки по месяцу года на странице истории. Теперь месяцы связаны с годом, раньше выбранный месяц отображал данные за все года выбранного месяца;